### PR TITLE
(feat): Add user creation email notifications

### DIFF
--- a/src/main/kotlin/co/innovaciones/bflow_server/service/EmailService.kt
+++ b/src/main/kotlin/co/innovaciones/bflow_server/service/EmailService.kt
@@ -34,8 +34,7 @@ EmailService(
         try {
             emailApi.sendTransacEmail(sendSmtpEmail)
         } catch (e: ApiException) {
-            log.error(e.code.toString() + ": " + e.message)
-            throw e
+            log.error("Email service replied with status " + e.code.toString() + ": " + e.responseBody)
         }
     }
 }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -11,6 +11,11 @@
       "description": "The sendinblue template to use when a new password is required."
     },
     {
+      "name": "sendinblue.template-user_created",
+      "type": "java.lang.Long",
+      "description": "The sendinblue template to use when a new user is created."
+    },
+    {
       "name": "sendinblue.action-url",
       "type": "java.lang.String",
       "description": "The URL of the Bflow client that will be used on the mails."

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,4 +71,5 @@ sendinblue:
   from-name: "Superior Homes"
   template-task-created: ${SENDINBLUE_TASK_TEMPLATE}
   template-password-change: ${SENDINBLUE_PASSWORD_TEMPLATE}
+  template-user-created: ${SENDINBLUE_USER_CREATED_TEMPLATE}
   action-url: "https://bflow.innovaciones.co"


### PR DESCRIPTION
- Add email notification when a new user is created
- Rename passwordNotifyEmail to notifyPasswordChangeRequest for better naming consistency
- Add configuration for user creation email template
- Improve error handling in EmailService
- Add logger to UserResource